### PR TITLE
chore: Improve error reporting

### DIFF
--- a/src/grz_cli/models/v1_0_0/metadata.py
+++ b/src/grz_cli/models/v1_0_0/metadata.py
@@ -901,16 +901,12 @@ class GrzSubmissionMetadata(StrictBaseModel):
                 if thresholds is None:
                     allowed_combinations = sorted(list(threshold_definitions.keys()))
                     allowed_combinations = "\n".join([f"  - {combination}" for combination in allowed_combinations])
-                    info = dict(
-                        zip(
-                            (
-                                "submission.genomic_study_subtype",
-                                "lab_datum.library_type",
-                                "lab_datum.sequence_subtype",
-                            ),
-                            key,
-                        )
+                    names = (
+                        "submission.genomic_study_subtype",
+                        "lab_datum.library_type",
+                        "lab_datum.sequence_subtype",
                     )
+                    info = dict(zip(names, key, strict=True))
                     log.warning(
                         f"No thresholds for the specified combination {info} found (donor {donor.tan_g})!\n"
                         f"Valid combinations:\n{allowed_combinations}.\n"

--- a/src/grz_cli/models/v1_0_0/metadata.py
+++ b/src/grz_cli/models/v1_0_0/metadata.py
@@ -902,9 +902,9 @@ class GrzSubmissionMetadata(StrictBaseModel):
                     allowed_combinations = sorted(list(threshold_definitions.keys()))
                     allowed_combinations = "\n".join([f"  - {combination}" for combination in allowed_combinations])
                     names = (
-                        "submission.genomic_study_subtype",
-                        "lab_datum.library_type",
-                        "lab_datum.sequence_subtype",
+                        "submission.genomicStudySubtype",
+                        "labData.libraryType",
+                        "labData.sequenceSubtype",
                     )
                     info = dict(zip(names, key, strict=True))
                     log.warning(

--- a/src/grz_cli/models/v1_0_0/metadata.py
+++ b/src/grz_cli/models/v1_0_0/metadata.py
@@ -899,7 +899,24 @@ class GrzSubmissionMetadata(StrictBaseModel):
                 )
                 thresholds = threshold_definitions.get(key)
                 if thresholds is None:
-                    log.warning(f"Thresholds for {key} not found! Skipping.")
+                    allowed_combinations = sorted(list(threshold_definitions.keys()))
+                    allowed_combinations = "\n".join([f"  - {combination}" for combination in allowed_combinations])
+                    info = dict(
+                        zip(
+                            (
+                                "submission.genomic_study_subtype",
+                                "lab_datum.library_type",
+                                "lab_datum.sequence_subtype",
+                            ),
+                            key,
+                        )
+                    )
+                    log.warning(
+                        f"No thresholds for the specified combination {info} found (donor {donor.tan_g})!\n"
+                        f"Valid combinations:\n{allowed_combinations}.\n"
+                        f"See https://www.bfarm.de/SharedDocs/Downloads/DE/Forschung/modellvorhaben-genomsequenzierung/Qs-durch-GRZ.pdf?__blob=publicationFile for more details.\n"
+                        f"Skipping threshold validation."
+                    )
                     continue
 
                 _check_thresholds(donor, lab_datum, thresholds)

--- a/src/grz_cli/parser.py
+++ b/src/grz_cli/parser.py
@@ -66,7 +66,7 @@ class SubmissionMetadata:
                     metadata_model = GrzSubmissionMetadata(**metadata)
                 except ValidationError as ve:
                     cls.__log.error("Invalid metadata format in metadata file: %s", file_path)
-                    raise SystemExit(ve)
+                    raise SystemExit(ve) from ve
                 return metadata_model
         except json.JSONDecodeError as e:
             cls.__log.error("Invalid JSON format in metadata file: %s", file_path)

--- a/src/grz_cli/parser.py
+++ b/src/grz_cli/parser.py
@@ -9,6 +9,8 @@ from itertools import groupby
 from os import PathLike
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from .download import S3BotoDownloadWorker
 from .fastq_validation import validate_paired_end_reads, validate_single_end_reads
 from .file_operations import Crypt4GH, calculate_sha256
@@ -60,7 +62,11 @@ class SubmissionMetadata:
         try:
             with open(file_path, encoding="utf-8") as jsonfile:
                 metadata = json.load(jsonfile)
-                metadata_model = GrzSubmissionMetadata(**metadata)
+                try:
+                    metadata_model = GrzSubmissionMetadata(**metadata)
+                except ValidationError as ve:
+                    cls.__log.error("Invalid metadata format in metadata file: %s", file_path)
+                    raise SystemExit(ve)
                 return metadata_model
         except json.JSONDecodeError as e:
             cls.__log.error("Invalid JSON format in metadata file: %s", file_path)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from grz_cli.parser import EncryptedSubmission, SubmissionMetadata
 
@@ -22,16 +23,17 @@ def test_submission_metadata(temp_metadata_file_path):
 
 
 def test_submission_metadata_fails():
-    with pytest.raises(ValueError, match="No read order specified for FASTQ file"):
+    error_types = (ValueError, ValidationError, SystemExit)
+    with pytest.raises(error_types, match="No read order specified for FASTQ file"):
         SubmissionMetadata(metadata_missing_read_order)
 
-    with pytest.raises(ValueError, match="BED file missing for lab datum"):
+    with pytest.raises(error_types, match="BED file missing for lab datum"):
         SubmissionMetadata(metadata_no_target_regions)
 
-    with pytest.raises(ValueError, match="VCF file missing for lab datum"):
+    with pytest.raises(error_types, match="VCF file missing for lab datum"):
         SubmissionMetadata(metadata_missing_vcf_file)
 
-    with pytest.raises(ValueError, match="Paired end sequencing layout but number of"):
+    with pytest.raises(error_types, match="Paired end sequencing layout but number of"):
         SubmissionMetadata(metadata_missing_fastq_r2)
 
 


### PR DESCRIPTION
- during threshold checks, if an error occurs, print a more informative message
- when a ValidationError occurs during model instantiation, only report the ValidationErrors, do not include the stacktrace