### PR TITLE
chore: include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include src/grz_cli/resources/grz-schema.json
+graft src
 include src/grz_cli/resources/thresholds.json
+include LICENSE


### PR DESCRIPTION
This is one way to resolve https://github.com/bioconda/bioconda-recipes/actions/runs/13973738531/job/39122090807?pr=54753#step:9:486
(this also removes the no-longer-in-use grz-schema.json and adds `graft src` for good measure; do we also want `graft tests`?)
A different way would be to put a LICENSE file next to the meta.yaml in the bioconda recipe, I think.