### PR TITLE
chore: use modern license specification format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "grz-cli"
 description = "Tool for validation, encryption and upload of MV submissions to GDCs."
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "Koray Kirli", email = "koraykirli@gmail.com" },
     { name = "Mathias Lesche", email = "mathias.lesche@tu-dresden.de" },
@@ -29,7 +29,6 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
 ]
 requires-python = ">=3.12"
@@ -207,6 +206,3 @@ follow_untyped_imports = true
 addopts = [
     "--import-mode=importlib",
 ]
-
-[tool.setuptools]
-license-files = []


### PR DESCRIPTION
setuptools will drop support for this format on 2026-02-18.

See [the docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files) for more details.

Triggered by a warning in the [bioconda build output](https://github.com/bioconda/bioconda-recipes/actions/runs/14493734614/job/40656258678#step:9:417).