### PR TITLE
feat: introduce `submit` subcommand for sequentially running validate, encrypt and upload

### DIFF
--- a/src/grz_cli/cli.py
+++ b/src/grz_cli/cli.py
@@ -326,7 +326,7 @@ def download(
 @click.pass_context
 def submit(ctx, submission_dir, config_file, threads):
     """
-    Sequentially invoke validate, encrypt and upload on a single submission.
+    Validate, encrypt, and then upload.
     """
     click.echo("Starting submission process...")
     ctx.invoke(validate, submission_dir=submission_dir)

--- a/src/grz_cli/cli.py
+++ b/src/grz_cli/cli.py
@@ -327,6 +327,11 @@ def download(
 def submit(ctx, submission_dir, config_file, threads):
     """
     Validate, encrypt, and then upload.
+
+    This is a convenience command that performs the following steps in order:
+    1. Validate the submission
+    2. Encrypt the submission
+    3. Upload the encrypted submission
     """
     click.echo("Starting submission process...")
     ctx.invoke(validate, submission_dir=submission_dir)

--- a/src/grz_cli/cli.py
+++ b/src/grz_cli/cli.py
@@ -319,6 +319,22 @@ def download(
     log.info("Download finished!")
 
 
+@cli.command("submit")
+@submission_dir
+@config_file
+@threads
+@click.pass_context
+def submit(ctx, submission_dir, config_file, threads):
+    """
+    Sequentially invoke validate, encrypt and upload on a single submission.
+    """
+    click.echo("Starting submission process...")
+    ctx.invoke(validate, submission_dir=submission_dir)
+    ctx.invoke(encrypt, submission_dir=submission_dir, config_file=config_file)
+    ctx.invoke(upload, submission_dir=submission_dir, config_file=config_file, threads=threads)
+    click.echo("Submission finished!")
+
+
 def read_config(config_path: str | PathLike) -> ConfigModel:
     """Reads the configuration file and validates it against the schema."""
     with open(config_path, encoding="utf-8") as f:


### PR DESCRIPTION
Nothing fancy, but fulfills the basic needs of #29