### PR TITLE
feat: fallback to environment for S3 credentials

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -16,8 +16,8 @@ grz_public_key: |2
 s3_options:
   endpoint_url: 'https://your-s3-url'
   bucket: 'your-s3-bucket-name'
-  access_key: 'your-s3-bucket-key'
-  secret: 'your-s3-bucket-secret'
+  access_key: 'your-s3-bucket-key'  # read from AWS_ACCESS_KEY_ID envvar if not provided
+  secret: 'your-s3-bucket-secret'  # read from AWS_SECRET_ACCESS_KEY envvar if not provided
   # request_checksum_calculation: "when_required"  # necessary on some S3 backends
   # multipart_chunksize: 268435456  # in bytes, 256MiB
 

--- a/src/grz_cli/models/config.py
+++ b/src/grz_cli/models/config.py
@@ -32,14 +32,16 @@ class S3Options(StrictBaseModel):
     The name of the S3 bucket.
     """
 
-    access_key: str
+    access_key: str | None = None
     """
     The access key for the S3 bucket.
+    If undefined, it is read from the AWS_ACCESS_KEY_ID environment variable.
     """
 
-    secret: str
+    secret: str | None = None
     """
     The secret key for the S3 bucket.
+    If undefined, it is read from the AWS_SECRET_ACCESS_KEY environment variable.
     """
 
     session_token: str | None = None


### PR DESCRIPTION
This makes the S3 credentials optional in the config file, allowing boto3 to read from the usual S3 environment variables if missing from the config file.

Resolves https://github.com/BfArM-MVH/grz-cli/issues/87