### PR TITLE
build: remove release trigger for PyPI and Docker workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-  release:
-    types: [published]
   push:
     tags:
       - 'v*'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,6 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Causes failures with PyPI deploys but also mostly redudant for Docker.